### PR TITLE
Fixed compilation with Zephyr Posix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "externals/qpcpp"]
 	path = externals/qpcpp
-	url = git@github.com:QuantumLeaps/qpcpp.git
+	url = https://github.com/QuantumLeaps/qpcpp.git

--- a/externals/qpcppCMakeSupport.txt
+++ b/externals/qpcppCMakeSupport.txt
@@ -1,4 +1,4 @@
-set(QP_CPP_TOP_DIR ${CMAKE_SOURCE_DIR}/externals/qpcpp)
+set(QP_CPP_TOP_DIR ${CMAKE_CURRENT_LIST_DIR}/../externals/qpcpp)
 set(QP_CPP_SRC_DIR ${QP_CPP_TOP_DIR}/src)
 set(QP_CPP_INCLUDE_DIR ${QP_CPP_TOP_DIR}/include)
 

--- a/test_support/cpputest-qpcpp-port/include/cmsDummyActiveObject.hpp
+++ b/test_support/cpputest-qpcpp-port/include/cmsDummyActiveObject.hpp
@@ -29,6 +29,7 @@
 #include "qpcpp.hpp"
 #include <array>
 #include <functional>
+#include <cstddef>
 
 namespace cms {
 

--- a/test_support/cpputest-qpcpp-port/src/cms_cpputest_q_onAssert.cpp
+++ b/test_support/cpputest-qpcpp-port/src/cms_cpputest_q_onAssert.cpp
@@ -50,5 +50,5 @@ Q_NORETURN Q_onAssert(char const* const file, int_t const loc)
       .withParameter("file", file)
       .withParameter("loc", loc);
 
-    TEST_EXIT
+    TEST_EXIT;
 }

--- a/test_support/cpputest-qpcpp-port/src/cms_cpputest_qf_ctrl.cpp
+++ b/test_support/cpputest-qpcpp-port/src/cms_cpputest_qf_ctrl.cpp
@@ -115,7 +115,7 @@ void Teardown()
             const size_t poolNumOfEvents = l_pubSubEventMemPoolConfigs->at(i).config.numberOfEvents;
 
             CHECK_TRUE_TEXT(poolNumOfEvents == QP::QF::ePool_[i].getNFree(),
-                            "A leak was detected in an internal QF event pool!")
+                            "A leak was detected in an internal QF event pool!");
         }
     }
 

--- a/test_support/cpputest-qpcpp-port/test/cms_cpputest_qf_ctrlTests.cpp
+++ b/test_support/cpputest-qpcpp-port/test/cms_cpputest_qf_ctrlTests.cpp
@@ -122,7 +122,7 @@ TEST(qf_ctrlTests,
             sigTwoCount++;
         }
         else {
-            TEST_EXIT
+            TEST_EXIT;
         }
     });
 


### PR DESCRIPTION
Adding this project via cmake with add_subdirectory did not work for integrating the project with zephyr. The main issues that are fixed are:
1. Fixed CPPUTest Macros that required semicolon.
2. Fixed size_t declaration without proper header.
3. Fixed directory path for compiling qpcpp.

In addition, the .gitmodules was changed to HTTPS access since for gitlab CI/CD retrieval via ssh is not possible (automatically).

Fixes #1 

Feel free to check out the changes I propose. Im open for any feedback as I just did this so I can integrate this with other tests that I need to develop with zephyr :)